### PR TITLE
Fixes iOS 8.2+ radio settings reverting to default

### DIFF
--- a/bin/lib/mappings.js
+++ b/bin/lib/mappings.js
@@ -43,7 +43,7 @@ module.exports = {
 		}
 	},
 	radio: {
-		ios: "PSRadioGroupSpecifier",
+		ios: "PSMultiValueSpecifier",
 		android: "ListPreference",
 		required: ["title", "key", "default"],
 		attrs: {


### PR DESCRIPTION
"PSRadioGroupSpecifier" settings on iOS 8.2+ reverts back on default when the apps settings gets focus. Using a PSMultiValueSpecifier has a different look and feel but works the same way.
See: http://stackoverflow.com/questions/34389422/ios-settings-bundle-psradiogroupspecifier-does-not-show-selected-value
